### PR TITLE
Update Reveal-MemoryCredentials.ps1

### DIFF
--- a/Reveal-MemoryCredentials/Reveal-MemoryCredentials.ps1
+++ b/Reveal-MemoryCredentials/Reveal-MemoryCredentials.ps1
@@ -1,5 +1,5 @@
 ﻿<#
-#requires -version 2
+#requires -version 3
 
 .SYNOPSIS         
     Reveal credentials from memory dump


### PR DESCRIPTION
Beginning in Windows PowerShell 3.0, the -shr (shift-right) and 
    -shl (shift-left) are added to support bitwise arithmetic in 
    Windows PowerShell.
